### PR TITLE
Correct bug with null queries

### DIFF
--- a/flask_whooshalchemy.py
+++ b/flask_whooshalchemy.py
@@ -119,7 +119,7 @@ class _QueryProxy(flask_sqlalchemy.BaseQuery):
             # be a query.
 
             # XXX is this efficient?
-            return self.filter('null')
+            return self.filter(sqlalchemy.text('null'))
 
         result_set = set()
         result_ranks = {}


### PR DESCRIPTION
Previously queries with no results would have raised this error: sqlalchemy.exc.ArgumentError: Textual SQL expression 'null' should be explicitly declared as text('null')